### PR TITLE
Fixup forego to work with nginx-proxy's alpine variant

### DIFF
--- a/command.go
+++ b/command.go
@@ -36,7 +36,7 @@ func (c *Command) Name() string {
 }
 
 func (c *Command) Runnable() bool {
-	return c.Run != nil && c.Disabled != true
+	return c.Run != nil && !c.Disabled
 }
 
 func (c *Command) List() bool {

--- a/command.go
+++ b/command.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 )
 
-var flagEnv string
 var flagProcfile string
 
 type Command struct {

--- a/env.go
+++ b/env.go
@@ -3,13 +3,10 @@ package main
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"sync"
 
 	"github.com/subosito/gotenv"
 )
-
-var envEntryRegexp = regexp.MustCompile("^([A-Za-z_0-9]+)=(.*)$")
 
 type Env struct {
 	m sync.Map

--- a/env.go
+++ b/env.go
@@ -88,9 +88,7 @@ func ReadEnv(filename string) (*Env, error) {
 }
 
 func (e *Env) asArray() (env []string) {
-	for _, pair := range os.Environ() {
-		env = append(env, pair)
-	}
+	env = append(env, os.Environ()...)
 
 	e.m.Range(func(name, val interface{}) bool {
 		env = append(env, fmt.Sprintf("%s=%s", name, val))

--- a/env_test.go
+++ b/env_test.go
@@ -10,11 +10,11 @@ func TestMultipleEnvironmentFiles(t *testing.T) {
 		t.Fatalf("Could not read environments: %s", err)
 	}
 
-	if env["env1"] == "" {
+	if env.Get("env1") == "" {
 		t.Fatal("$env1 should be present and is not")
 	}
 
-	if env["env2"] == "" {
+	if env.Get("env2") == "" {
 		t.Fatal("$env2 should be present and is not")
 	}
 }

--- a/process.go
+++ b/process.go
@@ -8,13 +8,13 @@ import (
 
 type Process struct {
 	Command     string
-	Env         Env
+	Env         *Env
 	Interactive bool
 
 	*exec.Cmd
 }
 
-func NewProcess(workdir, command string, env Env, interactive bool) (p *Process) {
+func NewProcess(workdir, command string, env *Env, interactive bool) (p *Process) {
 	argv := ShellInvocationCommand(interactive, workdir, command)
 	return &Process{
 		command, env, interactive, exec.Command(argv[0], argv[1:]...),

--- a/procfile.go
+++ b/procfile.go
@@ -68,7 +68,7 @@ func parseProcfile(r io.Reader) (*Procfile, error) {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("Reading Procfile: %s", err)
+		return nil, fmt.Errorf("reading Procfile: %s", err)
 	}
 	return pf, nil
 }

--- a/procfile.go
+++ b/procfile.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 )
 
-var procfileEntryRegexp = regexp.MustCompile("^([A-Za-z0-9_-]+):\\s*(.+)$")
+var procfileEntryRegexp = regexp.MustCompile(`^([A-Za-z0-9_-]+):\s*(.+)$`)
 
 type ProcfileEntry struct {
 	Name    string

--- a/start.go
+++ b/start.go
@@ -169,18 +169,19 @@ func (f *Forego) monitorInterrupt() {
 	}
 }
 
-func basePort(env Env) (int, error) {
+func basePort(env *Env) (int, error) {
+
 	if flagPort != defaultPort {
 		return flagPort, nil
-	} else if env["PORT"] != "" {
-		return strconv.Atoi(env["PORT"])
+	} else if port := env.Get("PORT"); port != "" {
+		return strconv.Atoi(port)
 	} else if os.Getenv("PORT") != "" {
 		return strconv.Atoi(os.Getenv("PORT"))
 	}
 	return defaultPort, nil
 }
 
-func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of *OutletFactory) {
+func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env *Env, of *OutletFactory) {
 	port, err := basePort(env)
 	if err != nil {
 		panic(err)
@@ -192,7 +193,8 @@ func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of 
 	workDir := filepath.Dir(flagProcfile)
 	ps := NewProcess(workDir, proc.Command, env, interactive)
 	procName := fmt.Sprint(proc.Name, ".", procNum+1)
-	ps.Env["PORT"] = strconv.Itoa(port)
+
+	ps.Env.Set("PORT", strconv.Itoa(port))
 
 	ps.Stdin = nil
 

--- a/start.go
+++ b/start.go
@@ -121,13 +121,13 @@ func parseConcurrency(value string) (map[string]int, error) {
 	parts := strings.Split(value, ",")
 	for _, part := range parts {
 		if !strings.Contains(part, "=") {
-			return concurrency, errors.New("Concurrency should be in the format: foo=1,bar=2")
+			return concurrency, errors.New("concurrency should be in the format: foo=1,bar=2")
 		}
 
 		nameValue := strings.Split(part, "=")
 		n, v := strings.TrimSpace(nameValue[0]), strings.TrimSpace(nameValue[1])
 		if n == "" || v == "" {
-			return concurrency, errors.New("Concurrency should be in the format: foo=1,bar=2")
+			return concurrency, errors.New("concurrency should be in the format: foo=1,bar=2")
 		}
 
 		numProcs, err := strconv.ParseInt(v, 10, 16)

--- a/start_test.go
+++ b/start_test.go
@@ -139,7 +139,7 @@ func TestPortFromEnv(t *testing.T) {
 	}
 
 	env.Set("PORT", "forego")
-	port, err = basePort(env)
+	_, err = basePort(env)
 	if err == nil {
 		t.Fatalf("Port 'forego' should fail: %s", err)
 	}

--- a/start_test.go
+++ b/start_test.go
@@ -111,7 +111,7 @@ func TestParseConcurrencyFlagNoValue(t *testing.T) {
 }
 
 func TestPortFromEnv(t *testing.T) {
-	env := make(Env)
+	env := NewEnv()
 	port, err := basePort(env)
 	if err != nil {
 		t.Fatalf("Can not get base port: %s", err)
@@ -129,7 +129,7 @@ func TestPortFromEnv(t *testing.T) {
 		t.Fatal("Base port should be 4000")
 	}
 
-	env["PORT"] = "6000"
+	env.Set("PORT", "6000")
 	port, err = basePort(env)
 	if err != nil {
 		t.Fatalf("Can not get base port: %s", err)
@@ -138,7 +138,7 @@ func TestPortFromEnv(t *testing.T) {
 		t.Fatal("Base port should be 6000")
 	}
 
-	env["PORT"] = "forego"
+	env.Set("PORT", "forego")
 	port, err = basePort(env)
 	if err == nil {
 		t.Fatalf("Port 'forego' should fail: %s", err)

--- a/unix.go
+++ b/unix.go
@@ -15,7 +15,7 @@ func ShellInvocationCommand(interactive bool, root, command string) []string {
 		shellArgument = "-ic"
 	}
 	shellCommand := fmt.Sprintf("cd \"%s\"; source .profile 2>/dev/null; exec %s", root, command)
-	return []string{"sh", shellArgument, shellCommand}
+	return []string{"bash", shellArgument, shellCommand}
 }
 
 func (p *Process) PlatformSpecificInit() {

--- a/unix.go
+++ b/unix.go
@@ -23,7 +23,6 @@ func (p *Process) PlatformSpecificInit() {
 		p.SysProcAttr = &syscall.SysProcAttr{}
 		p.SysProcAttr.Setsid = true
 	}
-	return
 }
 
 func (p *Process) SendSigTerm() {

--- a/unix.go
+++ b/unix.go
@@ -7,6 +7,8 @@ import (
 	"syscall"
 )
 
+var osShell string = "bash"
+
 const osHaveSigTerm = true
 
 func ShellInvocationCommand(interactive bool, root, command string) []string {
@@ -15,7 +17,7 @@ func ShellInvocationCommand(interactive bool, root, command string) []string {
 		shellArgument = "-ic"
 	}
 	shellCommand := fmt.Sprintf("cd \"%s\"; source .profile 2>/dev/null; exec %s", root, command)
-	return []string{"bash", shellArgument, shellCommand}
+	return []string{osShell, shellArgument, shellCommand}
 }
 
 func (p *Process) PlatformSpecificInit() {


### PR DESCRIPTION
This PR accumulates various fixes to make forego work with the latest nginx-proxy image on both the debian and alpine image. These are:

1.  It reverts https://github.com/nginx-proxy/forego/commit/51d9f6dc5ffb962e7efe4b461eca53d87587012c, which causes problems on `alpine` because the `sh` shell does not support all required features. 
2. It moves the shell to be used into a separate variable named `osShell` so that the shell can be customized at forego build time. For example:
```
go build -ldflags "-X main.osShell=sh" -o forego
```

can be used to make forego always use `sh` as opposed to `bash`. 

3. It protects the `env` map against concurrent accesses, these occur when a process crashes immediately on startup. 
4. Various minor fixes or stylistic go improvements