### PR TITLE
go.mod: fix module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nginxproxy/forego
+module github.com/nginx-proxy/forego
 
 go 1.11
 

--- a/go.sum
+++ b/go.sum
@@ -11,7 +11,6 @@ github.com/golangplus/testing v1.0.0 h1:+ZeeiKZENNOMkTTELoSySazi+XaEhVO0mb+eanrS
 github.com/golangplus/testing v1.0.0/go.mod h1:ZDreixUV3YzhoVraIDyOzHrr76p6NUh6k/pPg/Q3gYA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
The module name did not use a name that matched the github repository, causing it to fail:

    go install github.com/nginx-proxy/forego@latest
    go: downloading github.com/nginx-proxy/forego v0.17.0
    go install: github.com/nginx-proxy/forego@latest: github.com/nginx-proxy/forego@v0.17.0: parsing go.mod:
        module declares its path as: github.com/nginxproxy/forego
                but was required as: github.com/nginx-proxy/forego


introduced in https://github.com/nginx-proxy/forego/commit/75ad98c665d7ad3055a54a30bd392fc8c5dd03b7 (https://github.com/nginx-proxy/forego/pull/1)