### PR TITLE
feat: disable colored output if NO_COLOR is defined

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -70,6 +70,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          build-args: FOREGO_VERSION=${{ steps.forego_version.outputs.VERSION }}
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
           file: Dockerfile.${{ matrix.base }}
           sbom: true

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,9 +1,11 @@
+ARG FOREGO_VERSION=main
+
 # Build forego
 FROM --platform=$BUILDPLATFORM golang:1.21.5-alpine as go-builder
 
 ENV CGO_ENABLED=0
 
-ARG TARGETOS TARGETARCH TARGETVARIANT
+ARG FOREGO_VERSION TARGETOS TARGETARCH TARGETVARIANT
 ENV GOOS=$TARGETOS GOARCH=$TARGETARCH VARIANT=$TARGETVARIANT
 
 RUN apk add --no-cache musl-dev
@@ -21,10 +23,13 @@ RUN set -eu; \
 		*) [ -z "$VARIANT" ] ;; \
 	esac; \
 	go env | grep -E 'OS=|ARCH=|ARM=|AMD64='; \
-	go build -o forego .; \
+	go build -ldflags "-X main.buildVersion=${FOREGO_VERSION}" -o forego .; \
 	go clean -cache
 
 FROM --platform=$TARGETPLATFORM alpine:3.19.0
+
+ARG FOREGO_VERSION
+ENV FOREGO_VERSION=${FOREGO_VERSION}
 
 RUN apk add --no-cache bash
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,9 +1,11 @@
+ARG FOREGO_VERSION=main
+
 # Build forego
 FROM --platform=$BUILDPLATFORM golang:1.21.5 as go-builder
 
 ENV CGO_ENABLED=0
 
-ARG TARGETOS TARGETARCH TARGETVARIANT
+ARG FOREGO_VERSION TARGETOS TARGETARCH TARGETVARIANT
 ENV GOOS=$TARGETOS GOARCH=$TARGETARCH VARIANT=$TARGETVARIANT
 
 WORKDIR /build
@@ -19,10 +21,13 @@ RUN set -eu; \
 		*) [ -z "$VARIANT" ] ;; \
 	esac; \
 	go env | grep -E 'OS=|ARCH=|ARM=|AMD64='; \
-	go build -o forego .; \
+	go build -ldflags "-X main.buildVersion=${FOREGO_VERSION}" -o forego .; \
 	go clean -cache
 
 FROM --platform=$TARGETPLATFORM debian:12.4-slim
+
+ARG FOREGO_VERSION
+ENV FOREGO_VERSION=${FOREGO_VERSION}
 
 # Install Forego
 COPY --from=go-builder /build/forego /usr/local/bin/forego

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 BIN = forego
 SRC = $(shell find . -name '*.go')
 
+TAG:=`git describe --tags`
+LDFLAGS:=-X main.buildVersion=$(TAG)
+
 .PHONY: all build clean lint test
 
 all: build
@@ -20,4 +23,4 @@ test: lint get-deps build
 	go test -v -race -cover ./...
 
 $(BIN): $(SRC)
-	go build -o $@
+	go build -ldflags "$(LDFLAGS)" -o $@

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,9 @@ require (
 	github.com/subosito/gotenv v1.6.0
 )
 
-require golang.org/x/text v0.12.0 // indirect
+require (
+	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/term v0.15.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,14 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/stretchr/testify v1.7.5 h1:s5PTfem8p8EbKQOctVV53k6jCJt3UX4IEJzwh+C324Q=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
+golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
+golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
+golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
 golang.org/x/text v0.12.0 h1:k+n5B8goJNdU7hSvEtMUz3d1Q6D/XW4COJSJR6fN0mc=
 golang.org/x/text v0.12.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/outlet.go
+++ b/outlet.go
@@ -12,7 +12,7 @@ import (
 )
 
 type OutletFactory struct {
-	Padding int
+	LeftFormatter string
 
 	sync.Mutex
 }
@@ -80,8 +80,7 @@ func (of *OutletFactory) WriteLine(left, right string, leftC, rightC ct.Color, i
 	if colorize {
 		ct.ChangeColor(leftC, true, ct.None, false)
 	}
-	formatter := fmt.Sprintf("%%-%ds | ", of.Padding)
-	fmt.Printf(formatter, left)
+	fmt.Printf(of.LeftFormatter, left)
 
 	if colorize {
 		if isError {

--- a/outlet.go
+++ b/outlet.go
@@ -77,17 +77,21 @@ func (of *OutletFactory) WriteLine(left, right string, leftC, rightC ct.Color, i
 	of.Lock()
 	defer of.Unlock()
 
-	ct.ChangeColor(leftC, true, ct.None, false)
+	if colorize {
+		ct.ChangeColor(leftC, true, ct.None, false)
+	}
 	formatter := fmt.Sprintf("%%-%ds | ", of.Padding)
 	fmt.Printf(formatter, left)
 
-	if isError {
-		ct.ChangeColor(ct.Red, true, ct.None, true)
-	} else {
-		ct.ResetColor()
+	if colorize {
+		if isError {
+			ct.ChangeColor(rightC, true, ct.None, true)
+		} else {
+			ct.ResetColor()
+		}
 	}
 	fmt.Println(right)
-	if isError {
+	if colorize && isError {
 		ct.ResetColor()
 	}
 }

--- a/start.go
+++ b/start.go
@@ -91,7 +91,7 @@ func init() {
 	cmdStart.Flag.IntVar(&flagShutdownGraceTime, "t", defaultShutdownGraceTime, "shutdown grace time")
 	err := readConfigFile(".forego", &flagProcfile, &flagPort, &flagConcurrency, &flagShutdownGraceTime)
 	handleError(err)
-	colorize = terminal.IsTerminal(int(os.Stdout.Fd()))
+	colorize = os.Getenv("NO_COLOR") == "" && terminal.IsTerminal(int(os.Stdout.Fd()))
 }
 
 func readConfigFile(config_path string, flagProcfile *string, flagPort *int, flagConcurrency *string, flagShutdownGraceTime *int) error {

--- a/start.go
+++ b/start.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 const defaultPort = 5000
@@ -21,6 +23,7 @@ var flagConcurrency string
 var flagRestart bool
 var flagShutdownGraceTime int
 var envs envFiles
+var colorize bool
 
 var cmdStart = &Command{
 	Run:   runStart,
@@ -88,6 +91,7 @@ func init() {
 	cmdStart.Flag.IntVar(&flagShutdownGraceTime, "t", defaultShutdownGraceTime, "shutdown grace time")
 	err := readConfigFile(".forego", &flagProcfile, &flagPort, &flagConcurrency, &flagShutdownGraceTime)
 	handleError(err)
+	colorize = terminal.IsTerminal(int(os.Stdout.Fd()))
 }
 
 func readConfigFile(config_path string, flagProcfile *string, flagPort *int, flagConcurrency *string, flagShutdownGraceTime *int) error {

--- a/start.go
+++ b/start.go
@@ -281,7 +281,7 @@ func runStart(cmd *Command, args []string) {
 	handleError(err)
 
 	of := NewOutletFactory()
-	of.Padding = pf.LongestProcessName(concurrency)
+	of.LeftFormatter = fmt.Sprintf("%%-%ds | ", pf.LongestProcessName(concurrency))
 
 	f := &Forego{
 		outletFactory: of,

--- a/unix.go
+++ b/unix.go
@@ -1,4 +1,4 @@
-// +build darwin freebsd linux netbsd openbsd
+//go:build darwin || freebsd || linux || netbsd || openbsd
 
 package main
 
@@ -7,7 +7,7 @@ import (
 	"syscall"
 )
 
-var osShell string = "bash"
+var osShell string = "/bin/sh"
 
 const osHaveSigTerm = true
 
@@ -16,7 +16,7 @@ func ShellInvocationCommand(interactive bool, root, command string) []string {
 	if interactive {
 		shellArgument = "-ic"
 	}
-	shellCommand := fmt.Sprintf("cd \"%s\"; source .profile 2>/dev/null; exec %s", root, command)
+	shellCommand := fmt.Sprintf("cd \"%s\"; . ./.profile 2>/dev/null; exec %s", root, command)
 	return []string{osShell, shellArgument, shellCommand}
 }
 

--- a/unix.go
+++ b/unix.go
@@ -16,8 +16,8 @@ func ShellInvocationCommand(interactive bool, root, command string) []string {
 	if interactive {
 		shellArgument = "-ic"
 	}
-	shellCommand := fmt.Sprintf("cd \"%s\"; . ./.profile 2>/dev/null; exec %s", root, command)
-	return []string{osShell, shellArgument, shellCommand}
+	shellCommand := fmt.Sprintf("cd \"$1\"; . ./.profile 2>/dev/null; exec %s", command)
+	return []string{osShell, shellArgument, shellCommand, "sh", root}
 }
 
 func (p *Process) PlatformSpecificInit() {

--- a/unix.go
+++ b/unix.go
@@ -16,7 +16,7 @@ func ShellInvocationCommand(interactive bool, root, command string) []string {
 	if interactive {
 		shellArgument = "-ic"
 	}
-	shellCommand := fmt.Sprintf("cd \"$1\" || exit 66; test -e .profile && . ./.profile; exec %s", command)
+	shellCommand := fmt.Sprintf("cd \"$1\" || exit 66; test -f .profile && . ./.profile; exec %s", command)
 	return []string{osShell, shellArgument, shellCommand, "sh", root}
 }
 

--- a/unix.go
+++ b/unix.go
@@ -16,7 +16,7 @@ func ShellInvocationCommand(interactive bool, root, command string) []string {
 	if interactive {
 		shellArgument = "-ic"
 	}
-	shellCommand := fmt.Sprintf("cd \"$1\"; . ./.profile 2>/dev/null; exec %s", command)
+	shellCommand := fmt.Sprintf("cd \"$1\" || exit 66; test -e .profile && . ./.profile; exec %s", command)
 	return []string{osShell, shellArgument, shellCommand, "sh", root}
 }
 


### PR DESCRIPTION
This is a rebase of https://github.com/ddollar/forego/pull/124 by @sehrope

> This PR is a rebased version of #122 with a couple more commits added by me. That original PR improves the error handling and adds automatic disabling of color output based on whether stdout is a terminal.
> 
> This PR expands on that with a few more commits to:
> 
> 1. Checks for a NO_COLOR env variable and, if defined, disables color output regardless of whether we're running in a terminal (per https://no-color.org/)
> 
> ```shell
> $ NO_COLOR=1 forego start
> ...
> ```
> 
> 2. Optimize things a bit by only creating the "left" outlet formatter once. Previously it was being generated for ever line of output but the format itself never changes so it's wasted cycles.

The original PR also included this:
> 1. Add injecting a VERSION Makefile variable so you can include the date / commit in the resulting build. Defaults to current value of "dev":
> 
> ```shell
> $ make VERSION="$(date --utc +%Y%m%d-%H%M%S)-$(git show-ref -s -- HEAD)" build
> ...
> $ forego version
> 20200605-120321-0bdbf9b27cf9da13e246ff1ba90ab5961f4be849
> ```
Which has been replaced by a similar version injection closer to what we already do in docker-gen.

